### PR TITLE
remove cache to get current version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,5 +17,9 @@ ENV_DIR=$3
 # source=utils.sh
 source "$BIN_DIR/utils.sh"
 
+puts-step "read current version"
+version="$(curl -s https://structurizr.com/help/build/number)"
+url="https://static.structurizr.com/download/structurizr-lite-${version}.war"
+
 puts-step "Downloading Structurizr"
-curl -sL https://static.structurizr.com/download/structurizr-lite.war -o $BUILD_DIR
+curl -sL $url -o $BUILD_DIR/structurizr-lite.war

--- a/bin/compile
+++ b/bin/compile
@@ -17,12 +17,5 @@ ENV_DIR=$3
 # source=utils.sh
 source "$BIN_DIR/utils.sh"
 
-STRUCTURIZR_PATH=$CACHE_DIR/structurizr-lite.war
-
-if [ ! -f "$STRUCTURIZR_PATH" ]; then
-    puts-step "Downloading Structurizr"
-    curl -sL https://static.structurizr.com/download/structurizr-lite.war -o $STRUCTURIZR_PATH
-fi
-
-puts-step "Move compiled version to build dir"
-cp $STRUCTURIZR_PATH $BUILD_DIR
+puts-step "Downloading Structurizr"
+curl -sL https://static.structurizr.com/download/structurizr-lite.war -o $BUILD_DIR


### PR DESCRIPTION
**goal:**
Ensure that buildpack always uses the up to date version of structurizr lite.

**solution:**
Always download structurizr instead of reading from cache.