### PR TITLE
fix silent download failures and some lint

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 
 FROM heroku/heroku:22-build
+SHELL [ "/bin/bash", "-Eeuo", "pipefail", "-c" ]
 
 WORKDIR /app
 
@@ -8,11 +9,11 @@ ENV STACK=heroku-22
 RUN mkdir /tmp/structurizr-lite /tmp/structurizr-ui /app/structurizr-lite /app/structurizr-ui /var/build-cache
 
 # Download structurizr
-RUN curl -sLo- https://github.com/structurizr/lite/archive/refs/heads/main.tar.gz | tar xzf - -C /tmp/structurizr-lite
-RUN curl -sLo- https://github.com/structurizr/ui/archive/refs/heads/main.tar.gz | tar xzf - -C /tmp/structurizr-ui
+RUN curl -sfSLo- https://github.com/structurizr/lite/archive/refs/heads/main.tar.gz | tar xzf - -C /tmp/structurizr-lite && \
+curl -sfSLo- https://github.com/structurizr/ui/archive/refs/heads/main.tar.gz | tar xzf - -C /tmp/structurizr-ui
 
-RUN mv /tmp/structurizr-lite/lite-main/* /app/structurizr-lite/.
-RUN mv /tmp/structurizr-ui/ui-main/* /app/structurizr-ui/.
+RUN mv /tmp/structurizr-lite/lite-main/* /app/structurizr-lite/. && \
+mv /tmp/structurizr-ui/ui-main/* /app/structurizr-ui/.
 
 WORKDIR /app/structurizr-lite
 RUN ./ui.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ WORKDIR /app
 RUN echo "java.runtime.version=17.0.6" > /app/structurizr-lite/system.properties
 
 # Download the gradle buildpack
-RUN curl -sLo- https://github.com/heroku/heroku-buildpack-gradle/archive/refs/heads/main.tar.gz | tar xzf - -C /tmp
-RUN /tmp/heroku-buildpack-gradle-main/bin/compile /app/structurizr-lite /var/build-cache /var/env
+RUN curl -sfSLo- https://github.com/heroku/heroku-buildpack-gradle/archive/refs/heads/main.tar.gz | tar xzf - -C /tmp && \
+/tmp/heroku-buildpack-gradle-main/bin/compile /app/structurizr-lite /var/build-cache /var/env

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+lint: shellcheck hadolint
+.PHONY: lint
+
+shellcheck:
+	shellcheck bin/*
+.PHONY: shellcheck
+
+hadolint:
+	hadolint Dockerfile
+.PHONY: hadolint

--- a/bin/compile
+++ b/bin/compile
@@ -8,18 +8,23 @@
 set -eo pipefail
 
 # Paths.
-BIN_DIR=$(cd $(dirname $0); pwd) # absolute path
-ROOT_DIR=$(dirname $BIN_DIR)
+BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
+# ROOT_DIR=$(dirname "$BIN_DIR")
 BUILD_DIR=$1
-CACHE_DIR=$2
-ENV_DIR=$3
+# CACHE_DIR=$2
+# ENV_DIR=$3
 
-# source=utils.sh
+# shellcheck source=bin/utils.sh
 source "$BIN_DIR/utils.sh"
 
+curl_dl() {
+    # add standard "fail fast" parameters to a curl
+    curl --silent --fail --show-error --location "${@}"
+}
+
 puts-step "read current version"
-version="$(curl -s https://structurizr.com/help/build/number)"
+version="$(curl_dl https://structurizr.com/help/build/number)"
 url="https://static.structurizr.com/download/structurizr-lite-${version}.war"
 
 puts-step "downloading Structurizr build $version"
-curl -sL $url -o $BUILD_DIR/structurizr-lite.war
+curl_dl "$url" -o "$BUILD_DIR/structurizr-lite.war"

--- a/bin/detect
+++ b/bin/detect
@@ -3,6 +3,6 @@
 BUILD_DIR=$1
 
 # Exit early if app does not specify the relevant properties.
-if [ ! -f $BUILD_DIR/system.properties ]; then
+if [ ! -f "$BUILD_DIR/system.properties" ]; then
   exit 1
 fi


### PR DESCRIPTION
for some reason the `.war` file download url gives us an S3 "AccessDenied" error. sounds like structurizr has misconfigured (or removed) their bucket.

anyway, this is causing the `curl` download in our buildpack to download the XML error file, not an actual `.war` file.

two changes here:

1. adds some parameters to `curl` that will make it fail loudly when this happens
2. fixes some lint using [shellcheck](https://github.com/koalaman/shellcheck) and [hadolint](https://github.com/hadolint/hadolint/)