### PR TITLE
Fix/specify build number

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -23,7 +23,11 @@ curl_dl() {
 }
 
 puts-step "read current version"
-version="$(curl_dl https://structurizr.com/help/build/number)"
+if [ "${STRUCTURIZR_BUILD:-}" == "" ]; then
+    version="$(curl_dl https://structurizr.com/help/build/number)"
+else
+    version="${STRUCTURIZR_BUILD}"
+fi
 url="https://github.com/structurizr/lite/releases/download/v${version}/structurizr-lite.war"
 
 puts-step "downloading Structurizr build $version"

--- a/bin/compile
+++ b/bin/compile
@@ -24,11 +24,25 @@ curl_dl() {
 
 puts-step "read current version"
 if [ "${STRUCTURIZR_BUILD:-}" == "" ]; then
-    version="$(curl_dl https://structurizr.com/help/build/number)"
+    # user has not specified what specific build of structurizr to use. let's
+    # get latest release tag from github then!
+    #
+    # the GH API returns JSON, and we're interested in this property (example):
+    #
+    #     "tag_name": "v3124",
+    #
+    # the following regex does a look-ahead for the `"tag_name": "` part
+    # and then starts matching "v" plus some numbers (capturing the `v3124` part)
+    # 
+    tag_regex='(?<="tag_name": ")(v[0-9]+)'
+    version="$(
+        curl_dl "https://api.github.com/repos/structurizr/lite/releases/latest" \
+            | grep --perl-regexp --only-matching "${tag_regex}"
+    )"
 else
     version="${STRUCTURIZR_BUILD}"
 fi
-url="https://github.com/structurizr/lite/releases/download/v${version}/structurizr-lite.war"
+url="https://github.com/structurizr/lite/releases/download/${version}/structurizr-lite.war"
 
 puts-step "downloading Structurizr build $version"
 curl_dl "$url" -o "$BUILD_DIR/structurizr-lite.war"


### PR DESCRIPTION
first, I would LOVE to just use the Docker container in Heroku and ditch the buildpack. however some additional work is required to integrate oauth2-proxy with the docker container, and i don't think anyone has capacity to spare for that.

this will at least get Heroku working for now, until we can allocate more time to switch over to Docker.

two new features:

1. download latest .war file from github
2. if the above sketchy hack :point_up: stops working, then allow devs to manually specify the structurizr build number via environment variable
