### PR TITLE
fix github tag_name regex to work for any format

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ if [ "${STRUCTURIZR_BUILD:-}" == "" ]; then
     #
     # the following regex does a lookbehind for the `"tag_name": "` part
     # and then starts matching non-whitespace characters (\S) until it finds
-    # another quotation mark via a lookbehind: `(?=")`
+    # another quotation mark via a lookahead: `(?=")`
     #
     tag_regex='(?<="tag_name": ")(\S+)(?=")'
     version="$(

--- a/bin/compile
+++ b/bin/compile
@@ -29,12 +29,13 @@ if [ "${STRUCTURIZR_BUILD:-}" == "" ]; then
     #
     # the GH API returns JSON, and we're interested in this property (example):
     #
-    #     "tag_name": "v3124",
+    #     "tag_name": "2024.01.02",
     #
-    # the following regex does a look-ahead for the `"tag_name": "` part
-    # and then starts matching "v" plus some numbers (capturing the `v3124` part)
-    # 
-    tag_regex='(?<="tag_name": ")(v[0-9]+)'
+    # the following regex does a lookbehind for the `"tag_name": "` part
+    # and then starts matching non-whitespace characters (\S) until it finds
+    # another quotation mark via a lookbehind: `(?=")`
+    #
+    tag_regex='(?<="tag_name": ")(\S+)(?=")'
     version="$(
         curl_dl "https://api.github.com/repos/structurizr/lite/releases/latest" \
             | grep --perl-regexp --only-matching "${tag_regex}"


### PR DESCRIPTION
https://thermondo.atlassian.net/browse/TD-1018

structurizr [changed their version format](https://github.com/structurizr/lite/releases) which broke our "latest version detection" logic.

i made the regex a little more robust so it should work with almost any reasonable tag / version naming scheme in their repository.

this version of the buildpack is currently running in production. [build log](https://dashboard.heroku.com/apps/structurizr/activity/builds/9d8a9923-bdfa-4880-94dc-9df110f2d77c)

* [x] after merge, switch buildpack back to master branch